### PR TITLE
Logical timestamp

### DIFF
--- a/internal/math/utils.go
+++ b/internal/math/utils.go
@@ -1,0 +1,9 @@
+package math
+
+func Max(x, y int) int {
+	if x > y {
+		return x
+	} else {
+		return y
+	}
+}

--- a/internal/time/lamportTimestamp.go
+++ b/internal/time/lamportTimestamp.go
@@ -6,9 +6,25 @@ import (
 	math "github.com/goose-alt/chitty-chat/internal/math"
 )
 
+var (
+	instance *LamportTimestamp
+)
+
+
+
 type LamportTimestamp struct {
 	time int
 	lock sync.Mutex
+}
+
+func GetLamportTimeStamp() *LamportTimestamp {
+
+	if instance == nil {
+		timestamp := LamportTimestamp{}
+		instance = &timestamp
+	}
+
+	return instance
 }
 
 func (v *LamportTimestamp) Sync(timestamp LamportTimestamp) {

--- a/internal/time/lamportTimestamp.go
+++ b/internal/time/lamportTimestamp.go
@@ -17,6 +17,9 @@ func GetLamportTimeStamp() LamportTimestamp {
 	return LamportTimestamp{time: 0, lock: sync.Mutex{}}
 }
 
+/*
+Synchronizes the two timestamps so that the logical timestamp is updated.
+*/
 func (v *LamportTimestamp) Sync(timestamp LamportTimestamp) {
 	v.lock.Lock()
 	v.time = math.Max(timestamp.time, v.time)

--- a/internal/time/lamportTimestamp.go
+++ b/internal/time/lamportTimestamp.go
@@ -3,14 +3,13 @@ package time
 import (
 	"strconv"
 	"sync"
+
 	math "github.com/goose-alt/chitty-chat/internal/math"
 )
 
 var (
 	instance *LamportTimestamp
 )
-
-
 
 type LamportTimestamp struct {
 	time int
@@ -20,7 +19,7 @@ type LamportTimestamp struct {
 func GetLamportTimeStamp() *LamportTimestamp {
 
 	if instance == nil {
-		timestamp := LamportTimestamp{}
+		timestamp := LamportTimestamp{time: 0, lock: sync.Mutex{}}
 		instance = &timestamp
 	}
 

--- a/internal/time/lamportTimestamp.go
+++ b/internal/time/lamportTimestamp.go
@@ -7,23 +7,14 @@ import (
 	math "github.com/goose-alt/chitty-chat/internal/math"
 )
 
-var (
-	instance *LamportTimestamp
-)
-
 type LamportTimestamp struct {
 	time int
 	lock sync.Mutex
 }
 
-func GetLamportTimeStamp() *LamportTimestamp {
+func GetLamportTimeStamp() LamportTimestamp {
 
-	if instance == nil {
-		timestamp := LamportTimestamp{time: 0, lock: sync.Mutex{}}
-		instance = &timestamp
-	}
-
-	return instance
+	return LamportTimestamp{time: 0, lock: sync.Mutex{}}
 }
 
 func (v *LamportTimestamp) Sync(timestamp LamportTimestamp) {

--- a/internal/time/lamportTimestamp.go
+++ b/internal/time/lamportTimestamp.go
@@ -1,0 +1,28 @@
+package time
+
+import (
+	"strconv"
+	"sync"
+	math "github.com/goose-alt/chitty-chat/internal/math"
+)
+
+type LamportTimestamp struct {
+	time int
+	lock sync.Mutex
+}
+
+func (v *LamportTimestamp) Sync(timestamp LamportTimestamp) {
+	v.lock.Lock()
+	v.time = math.Max(timestamp.time, v.time)
+	v.lock.Unlock()
+}
+
+func (v *LamportTimestamp) GetDisplayableContent() string {
+	return strconv.Itoa(v.time)
+}
+
+func (v *LamportTimestamp) Increment() {
+	v.lock.Lock()
+	v.time += 1
+	v.lock.Unlock()
+}

--- a/internal/time/logicalTimestamp.go
+++ b/internal/time/logicalTimestamp.go
@@ -7,6 +7,9 @@ NOTE: Due to the limitations of GoLang then a sync method is not defined in this
 When generics becomes available then the method should be defined.
 */
 type LogicalTimestamp interface {
+	/* Increments the timestamp by 1 */
 	Increment()
+
+	/* Returns the timestamp as a displayable string */
 	GetDisplayableContent() string
 }

--- a/internal/time/logicalTimestamp.go
+++ b/internal/time/logicalTimestamp.go
@@ -1,0 +1,11 @@
+package time
+
+/*
+Defines common methods for a logical timestamp
+NOTE: 	Due to the limitations of GoLang then a sync method is not defined in this interface. 
+		When generics becomes available then the method should be defined.
+*/
+type LogicalTimestamp interface {
+	Increment()
+	GetDisplayableContent() string
+}

--- a/internal/time/logicalTimestamp.go
+++ b/internal/time/logicalTimestamp.go
@@ -1,9 +1,10 @@
 package time
 
 /*
-Defines common methods for a logical timestamp
-NOTE: 	Due to the limitations of GoLang then a sync method is not defined in this interface. 
-		When generics becomes available then the method should be defined.
+Defines common methods for a logical timestamp.
+
+NOTE: Due to the limitations of GoLang then a sync method is not defined in this interface. 
+When generics becomes available then the method should be defined.
 */
 type LogicalTimestamp interface {
 	Increment()

--- a/internal/time/vectorTimestamp.go
+++ b/internal/time/vectorTimestamp.go
@@ -42,9 +42,6 @@ func (v VectorTimestamp) Sync(foreignTime VectorTimestamp) {
 	}
 }
 
-/*
-Returns the timestamp as a displayble string.
-*/
 func (v VectorTimestamp) GetDisplayableContent() string {
 
 	v.lock.Lock()
@@ -53,9 +50,6 @@ func (v VectorTimestamp) GetDisplayableContent() string {
 	return strconv.Itoa(v.time)
 }
 
-/*
-Increments the timestamp by 1
-*/
 func (v VectorTimestamp) Increment() {
 
 	v.lock.Lock()

--- a/internal/time/vectorTimestamp.go
+++ b/internal/time/vectorTimestamp.go
@@ -1,0 +1,57 @@
+package time
+
+import (
+	"strconv"
+	"sync"
+
+	math "github.com/goose-alt/chitty-chat/internal/math"
+)
+
+type VectorTimestamp struct {
+	ClientId   string
+	VectorTime map[string]int
+	time       int
+	lock       sync.Mutex
+}
+
+func CreateVectorTimestamp(clientId string) VectorTimestamp {
+
+	return VectorTimestamp{
+		ClientId:   clientId,
+		VectorTime: make(map[string]int),
+		lock:       sync.Mutex{},
+	}
+}
+
+func (v VectorTimestamp) Sync(foreignTime VectorTimestamp) {
+
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	v.time = 0 // Reset time and count again
+
+	for key, vt := range foreignTime.VectorTime {
+		
+		maxValue := math.Max(v.VectorTime[key], vt)
+
+		v.VectorTime[key] = maxValue
+		v.time += maxValue
+	}
+}
+
+func (v VectorTimestamp) GetDisplayableContent() string {
+
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	return strconv.Itoa(v.time)
+}
+
+func (v VectorTimestamp) Increment() {
+
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	v.VectorTime[v.ClientId] += 1
+	v.time += 1
+}

--- a/internal/time/vectorTimestamp.go
+++ b/internal/time/vectorTimestamp.go
@@ -9,7 +9,7 @@ import (
 
 type VectorTimestamp struct {
 	ClientId   string
-	VectorTime map[string]int
+	vectorTime map[string]int
 	time       int
 	lock       sync.Mutex
 }
@@ -18,7 +18,7 @@ func CreateVectorTimestamp(clientId string) VectorTimestamp {
 
 	return VectorTimestamp{
 		ClientId:   clientId,
-		VectorTime: make(map[string]int),
+		vectorTime: make(map[string]int),
 		lock:       sync.Mutex{},
 	}
 }
@@ -33,13 +33,17 @@ func (v VectorTimestamp) Sync(foreignTime VectorTimestamp) {
 
 	v.time = 0 // Reset time and count again
 
-	for key, vt := range foreignTime.VectorTime {
+	for key, vt := range foreignTime.GetVectorTime() {
 		
-		maxValue := math.Max(v.VectorTime[key], vt)
+		maxValue := math.Max(v.vectorTime[key], vt)
 
-		v.VectorTime[key] = maxValue
+		v.vectorTime[key] = maxValue
 		v.time += maxValue
 	}
+}
+
+func (v VectorTimestamp) GetVectorTime() map[string]int {
+	return v.vectorTime
 }
 
 func (v VectorTimestamp) GetDisplayableContent() string {
@@ -55,6 +59,6 @@ func (v VectorTimestamp) Increment() {
 	v.lock.Lock()
 	defer v.lock.Unlock()
 
-	v.VectorTime[v.ClientId] += 1
+	v.vectorTime[v.ClientId] += 1
 	v.time += 1
 }

--- a/internal/time/vectorTimestamp.go
+++ b/internal/time/vectorTimestamp.go
@@ -23,6 +23,9 @@ func CreateVectorTimestamp(clientId string) VectorTimestamp {
 	}
 }
 
+/*
+Synchronizes the two timestamps so that the logical timestamp is updated.
+*/
 func (v VectorTimestamp) Sync(foreignTime VectorTimestamp) {
 
 	v.lock.Lock()
@@ -39,6 +42,9 @@ func (v VectorTimestamp) Sync(foreignTime VectorTimestamp) {
 	}
 }
 
+/*
+Returns the timestamp as a displayble string.
+*/
 func (v VectorTimestamp) GetDisplayableContent() string {
 
 	v.lock.Lock()
@@ -47,6 +53,9 @@ func (v VectorTimestamp) GetDisplayableContent() string {
 	return strconv.Itoa(v.time)
 }
 
+/*
+Increments the timestamp by 1
+*/
 func (v VectorTimestamp) Increment() {
 
 	v.lock.Lock()


### PR DESCRIPTION
Hey everyone,

This is a feature that has both the implementation of the Lamport and Vector timestamp.

The following 3 files has been added:
- logicalTimeStamp.go (Is the interface with the most common shared methods)
- lamportTimestamp.go
- vectorTimestamp.go